### PR TITLE
Allow more color identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,18 +35,7 @@ BigText.propTypes = {
 		'right'
 	]),
 	colors: PropTypes.arrayOf(
-		PropTypes.oneOf([
-			'system',
-			'black',
-			'red',
-			'green',
-			'yellow',
-			'blue',
-			'magenta',
-			'cyan',
-			'white',
-			'gray'
-		])
+		PropTypes.string,
 	),
 	backgroundColor: PropTypes.oneOf([
 		'transparent',


### PR DESCRIPTION
Hello @sindresorhus,

I wrote [a ReasonML binding](https://github.com/cometkim/reason-ink/blob/master/packages/ink-big-text/src/ReasonInkCommunity_BigText.re) that supports all cfonts colors, but ink-big-text is outputting a warning.

![image](https://user-images.githubusercontent.com/9696352/82601150-0f536e80-9bea-11ea-9dff-bf7d9f288046.png)

cfonts actually supports more types of string like `yelloBright` and hex code.

https://github.com/dominikwilkowski/cfonts#-c---colors

I would like to remove the prop types check here.

