### PR TITLE
fix(readme): Fix link for props

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ render(
 
 ### `<BigText/>`
 
-Props except for `text` are passed as options to [`cfonts`](https://github.com/dominikwilkowski/cfonts). The only difference is that the `background` option is named `backgroundColor` here. See the prop types in [`index.js`](index.js) for more.
+Props except for `text` are passed as options to [`cfonts`](https://github.com/dominikwilkowski/cfonts). The only difference is that the `background` option is named `backgroundColor` here. See the prop types in [`index.tsx`](https://github.com/sindresorhus/ink-big-text/blob/main/source/index.tsx#L5) for more.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ render(
 
 ### `<BigText/>`
 
-Props except for `text` are passed as options to [`cfonts`](https://github.com/dominikwilkowski/cfonts). The only difference is that the `background` option is named `backgroundColor` here. See the prop types in [`index.tsx`](https://github.com/sindresorhus/ink-big-text/blob/main/source/index.tsx#L5) for more.
+Props except for `text` are passed as options to [`cfonts`](https://github.com/dominikwilkowski/cfonts). The only difference is that the `background` option is named `backgroundColor` here. See the prop types in [`index.tsx`](source/index.tsx#L5) for more.
 
 ## Related
 


### PR DESCRIPTION
The file `index.js` mentioned in the README does not exist. Pointing link to `index.tsx` where the props are located.